### PR TITLE
Add title prefix exceptions

### DIFF
--- a/exceptioncheck.ts
+++ b/exceptioncheck.ts
@@ -1,0 +1,10 @@
+const core = require("@actions/core");
+
+module.exports = {
+  find: (prefix, title) => {
+    const titleRegex = RegExp(`(^${prefix}:.*$)`);
+    if (titleRegex.test(title)) {
+      return prefix;
+    }
+  },
+};

--- a/tests.js
+++ b/tests.js
@@ -1,5 +1,6 @@
 const assert = require('assert/strict');
 const issuecheck = require('./issuecheck.js');
+const exceptioncheck = require('./exceptioncheck.ts');
 
 const tests = {
   testNoneContains: () => {
@@ -64,6 +65,20 @@ const tests = {
     );
     assert.equal(issue, "ENG-1234");
   },
+  testTitlePrefixException: () => {
+    const exception = exceptioncheck.find(
+      "nit",
+      "nit: ENG-1234 Something of value",
+    );
+    assert.equal(exception, "nit");
+  },
+  testTitlePrefixNoException: () => {
+    const exception = exceptioncheck.find(
+      "nit",
+      "feat: ENG-1234 Something of value",
+    );
+    assert.equal(exception, undefined);
+  },
 };
 
 function run() {
@@ -71,7 +86,7 @@ function run() {
     try {
       test()
       console.log(`${key} passed`)
-    } catch(error) {
+    } catch (error) {
       console.log(`${key} failed: ${error}`)
     }
   }


### PR DESCRIPTION
Addressing some discussion around the linear check being too eager (admittedly a lot of it was by me), and that we can have the check be smarter for nits at least (and possibly smaller functional refactors though these are hard to disambiguate). https://phantom-wallet.slack.com/archives/C032GN6KVS9/p1668184656387309?thread_ts=1668100005.132179&cid=C032GN6KVS9

Resolves ECO-819. 

The actual prefixes that trigger the exception is updated in the Github Actions config in the respective repos. 