### PR TITLE
fix: Remove colon requirement on prefix.

### DIFF
--- a/exceptioncheck.ts
+++ b/exceptioncheck.ts
@@ -2,7 +2,7 @@ const core = require("@actions/core");
 
 module.exports = {
   find: (prefix, title) => {
-    const titleRegex = RegExp(`(^${prefix}:.*$)`);
+    const titleRegex = RegExp(`(^${prefix}.*$)`);
     if (titleRegex.test(title)) {
       return prefix;
     }

--- a/tests.js
+++ b/tests.js
@@ -79,6 +79,34 @@ const tests = {
     );
     assert.equal(exception, undefined);
   },
+  testTitlePrefixWithParenthesesNoException: () => {
+    const exception = exceptioncheck.find(
+      "nit",
+      "feat(somefeature): ENG-1234 Something of value",
+    );
+    assert.equal(exception, undefined);
+  },
+  testTitlePrefixWithParenthesesException: () => {
+    const exception = exceptioncheck.find(
+      "nit",
+      "nit(somefeature): ENG-1234 Something of value",
+    );
+    assert.equal(exception, "nit");
+  },
+  testTitlePrefixWithBracketsNoException: () => {
+    const exception = exceptioncheck.find(
+      "nit",
+      "feat[somefeature]: ENG-1234 Something of value",
+    );
+    assert.equal(exception, undefined);
+  },
+  testTitlePrefixWithBracketsException: () => {
+    const exception = exceptioncheck.find(
+      "nit",
+      "nit[somefeature]: ENG-1234 Something of value",
+    );
+    assert.equal(exception, "nit");
+  },
 };
 
 function run() {


### PR DESCRIPTION
Fixes exception check failing when there is a scope specified in PR title.